### PR TITLE
Improve MIDI port typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.2.0",
       "license": "BSD2",
       "dependencies": {
-        "jzz": "^1.5.1"
+        "jzz": "^1.5.1",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
@@ -4136,6 +4137,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "jzz": "^1.5.1"
+    "jzz": "^1.5.1",
+    "tslib": "^2.8.1"
   }
 }

--- a/src/Service/Midi/index.ts
+++ b/src/Service/Midi/index.ts
@@ -1,5 +1,8 @@
 import midi from 'jzz';
 
+type EngineAsync = ReturnType<typeof midi>;
+type JzzPort = ReturnType<EngineAsync['openMidiOut']>;
+
 class midiError extends Error {
   constructor(message: string) {
     super(message);
@@ -8,8 +11,8 @@ class midiError extends Error {
 }
 
 export default class MidiService {
-  private _midiInput = midi().openMidiOut();
-  private _midiOutput = midi().openMidiOut();
+  private _midiInput: JzzPort = midi().openMidiOut();
+  private _midiOutput: JzzPort = midi().openMidiOut();
 
   private _midiIn: string;
   private _midiOut: string;
@@ -40,7 +43,7 @@ export default class MidiService {
     this._midiOutput.close();
   }
 
-  public get out(): any {
+  public get out(): JzzPort {
     this.openOutput();
     setTimeout(() => {
       this.closeOutput();
@@ -48,7 +51,7 @@ export default class MidiService {
     return this._midiOutput;
   }
 
-  public get in(): any {
+  public get in(): JzzPort {
     return this._midiInput;
   }
 


### PR DESCRIPTION
## Summary
- type `MidiService` ports using JZZ return types
- include `tslib` dependency for build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6843114d4a2083299695f163ce7cef0b