### PR TITLE
Add web MIDI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ For yarn:
   yarn add launchpadcore
 ```
 
+When running in a browser, the library automatically calls
+`navigator.requestMIDIAccess()` to request access to the Web MIDI API.
+
 ## Supported devices
 Launchpad Core offers a driver system to adapt to the different existing models of Novation Launchpad.
 ### MK1

--- a/src/Service/Midi/index.ts
+++ b/src/Service/Midi/index.ts
@@ -61,4 +61,14 @@ export default class MidiService {
     this._midiOutput.close();
     this._midiInput.close();
   }
+
+  public static async requestWebAccess() {
+    if (typeof navigator !== 'undefined' && (navigator as any).requestMIDIAccess) {
+      try {
+        await (navigator as any).requestMIDIAccess({ sysex: true });
+      } catch {
+        // ignore failure in case user rejects access
+      }
+    }
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ class LaunchpadCore<T extends StringDrivers> {
   private readonly _instance: MidiService;
   private readonly _driver: DriverMap[T];
 
+  private static isBrowser(): boolean {
+    return typeof window !== 'undefined' && typeof navigator !== 'undefined';
+  }
+
   private callbacks: { [e: string]: any[] } = {
     onMidiIn: [],
     onConnected: [],
@@ -14,12 +18,19 @@ class LaunchpadCore<T extends StringDrivers> {
 
   constructor(driverName: T) {
     this._driver = DriverManager.getDriver(driverName);
+
+    if (LaunchpadCore.isBrowser()) {
+      MidiService.requestWebAccess().catch(() => {});
+    }
+
     this._instance = new MidiService(this._driver.MidiIn, this._driver.MidiOut);
 
     this.onEnabled();
 
-    process.on('SIGINT', () => this.onDisabled());
-    process.on('EXIT', () => this.onDisabled());
+    if (typeof process !== 'undefined' && process.on) {
+      process.on('SIGINT', () => this.onDisabled());
+      process.on('EXIT', () => this.onDisabled());
+    }
   }
 
   private async onEnabled() {


### PR DESCRIPTION
## Summary
- auto request MIDI access when running in the browser
- guard node-only code against browser context
- document automatic Web MIDI request

## Testing
- `npm run build` *(fails: rollup not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68431aeaadc483298d05baa7a798373a