### PR TITLE
Add automatic Launchpad detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Launchpad Core offers a driver system to adapt to the different existing models 
 Here is a typical example of what can be done with this module.
 
 ```javascript
-import { createLaunchpadCore } from "launchpadcore";
+import { createLaunchpadCore, autoDetectLaunchpadCore } from "launchpadcore";
 
+// Manual mode
 const App = createLaunchpadCore("LaunchpadX");
 
 App.on("onEnabled", (instance, driver) => {
@@ -67,6 +68,10 @@ App.on("onMidiIn", (data) => {
 App.on("onDisabled", () => {
     console.log("Shutdown...")
 })
+
+// Automatic detection (Node and Browser)
+// Returns the first connected Launchpad supported by the library
+const AutoApp = await autoDetectLaunchpadCore();
 ```
 
 ## What's can I do ?

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,6 +1,7 @@
-import { createLaunchpadCore } from "../src/";
+import { createLaunchpadCore, autoDetectLaunchpadCore } from "../src/";
 
-const App = createLaunchpadCore("LaunchpadX");
+//const App = createLaunchpadCore("LaunchpadX");
+const App = autoDetectLaunchpadCore();
 
 App.on("onConnected", (instance, driver) => {
     console.log(instance.out.info());
@@ -18,3 +19,4 @@ App.on("onDisabled", (instance, driver) => {
     instance.out.send(driver.programmerToggle(false))
     console.log("Shutdown...")
 })
+

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -1,20 +1,22 @@
-import { createLaunchpadCore, autoDetectLaunchpadCore } from "../src/";
+import { autoDetectLaunchpadCore } from '../src';
 
-//const App = createLaunchpadCore("LaunchpadX");
-const App = autoDetectLaunchpadCore();
+(async () => {
+  const app = await autoDetectLaunchpadCore();
+  app.on('onConnected', (instance, driver) => {
+    // instance.out.send(driver.textScrolling(15, 'Welcome!'))
+    instance.out.send(driver.programmerToggle(true));
+    instance.out.noteOn(0, 11, 25); // Pad 11 to color 25
+  });
+  app.on('onMidiIn', (data) => {
+    console.log(data);
+  });
 
-App.on("onConnected", (instance, driver) => {
-    console.log(instance.out.info());
-    //instance.out.send(driver.textScrolling(15, "Welcome!"))
-    instance.out.send(driver.programmerToggle(true))
-    instance.out.noteOn(0, 11, 25) // Pad 11 to color 25
-})
-
-App.on("onMidiIn", (data) => {
-    console.log(data)
-})
-
-App.on("onDisabled", (instance, driver) => {
+  app.on('onDisabled', (instance, driver) => {
+    instance.out.send(driver.textScrolling(15, 'Goodbye!'));
+    instance.out.send(driver.programmerToggle(false));
+    console.log('Shutdown...');
+  });
+})();
     instance.out.send(driver.textScrolling(15, "Goodbye!"))
     instance.out.send(driver.programmerToggle(false))
     console.log("Shutdown...")

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,12 +83,6 @@ export function createLaunchpadCore<T extends StringDrivers>(driverName: T) {
 }
 
 export async function autoDetectLaunchpadCore() {
-  const isBrowser = typeof window !== 'undefined' && typeof navigator !== 'undefined';
-
-  if (isBrowser) {
-    await MidiService.requestWebAccess().catch(() => {});
-  }
-
   const engine = midi();
   await engine.refresh().or(() => {});
   const info = engine.info();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import DriverManager, { DriverMap, StringDrivers } from './Drivers';
+import midi from 'jzz';
+import DriverManager, { DriverMap, StringDrivers, driverMap } from './Drivers';
 import MidiService from './Service/Midi';
 
 class LaunchpadCore<T extends StringDrivers> {
@@ -79,4 +80,27 @@ export { LaunchpadCore };
 
 export function createLaunchpadCore<T extends StringDrivers>(driverName: T) {
   return new LaunchpadCore<T>(driverName);
+}
+
+export async function autoDetectLaunchpadCore() {
+  const isBrowser = typeof window !== 'undefined' && typeof navigator !== 'undefined';
+
+  if (isBrowser) {
+    await MidiService.requestWebAccess().catch(() => {});
+  }
+
+  const engine = midi();
+  await engine.refresh().or(() => {});
+  const info = engine.info();
+
+  for (const name of Object.keys(driverMap) as Array<StringDrivers>) {
+    const driver = driverMap[name];
+    const hasIn = info.inputs.some((p: any) => p.name === driver.MidiIn);
+    const hasOut = info.outputs.some((p: any) => p.name === driver.MidiOut);
+    if (hasIn && hasOut) {
+      return new LaunchpadCore(name);
+    }
+  }
+
+  throw new Error('No compatible Launchpad device found');
 }


### PR DESCRIPTION
## Summary
- add `autoDetectLaunchpadCore` helper to detect connected launchpads
- document the new helper with usage example

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68431cc816908329b0f049c4ef69ca87