### PR TITLE
Add device disconnection event

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import { createLaunchpadCore } from "launchpadcore";
 
 const App = createLaunchpadCore("LaunchpadX");
 
-App.on("onEnabled", (instance, driver) => {
+App.on("onConnected", (instance, driver) => {
     instance.out.send(driver.textScrolling(15, "Welcome!"))
     instance.out.noteOn(0, 11, 25) // Pad 11 to color 25
 })

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ App.on("onMidiIn", (data) => {
 App.on("onDisabled", () => {
     console.log("Shutdown...")
 })
+
+App.on("onDisconnected", () => {
+    console.log("Device disconnected")
+})
 ```
 
 ## What's can I do ?
@@ -74,9 +78,10 @@ App.on("onDisabled", () => {
 ### Events
 | Name        | Description                |
 | :---------- | :------------------------- |
-| `onConnected` | When connected to Launchpad | 
-| `onDisabled` | When disabled (exit the program) | 
-| `onMidiIn` | When new MIDI message received | 
+| `onConnected` | When connected to Launchpad |
+| `onDisabled` | When disabled (exit the program) |
+| `onDisconnected` | When the device disconnects |
+| `onMidiIn` | When new MIDI message received |
 
 
 ### MIDI methods

--- a/src/Service/Midi/index.ts
+++ b/src/Service/Midi/index.ts
@@ -16,27 +16,30 @@ export default class MidiService {
 
   private _midiIn: string;
   private _midiOut: string;
+  private _onDisconnect?: () => void;
 
-  constructor(midiIn: string, midiOut: string) {
+  constructor(midiIn: string, midiOut: string, onDisconnect?: () => void) {
     this._midiIn = midiIn;
     this._midiOut = midiOut;
+    this._onDisconnect = onDisconnect;
 
     this._midiInput = midi()
       .openMidiIn(midiIn)
-      .or(() => this.midiError);
+      .or(() => this.midiError());
     this._midiOutput = midi()
       .openMidiOut(midiIn)
-      .or(() => this.midiError);
+      .or(() => this.midiError());
   }
 
-  private get midiError() {
+  private midiError() {
+    if (this._onDisconnect) this._onDisconnect();
     throw new midiError('Device not connected.');
   }
 
   private openOutput() {
     this._midiOutput = midi()
       .openMidiOut(this._midiOut)
-      .or(() => this.midiError);
+      .or(() => this.midiError());
   }
 
   private closeOutput() {

--- a/src/Service/Midi/index.ts
+++ b/src/Service/Midi/index.ts
@@ -27,13 +27,16 @@ export default class MidiService {
       .openMidiIn(midiIn)
       .or(() => this.midiError());
     this._midiOutput = midi()
-      .openMidiOut(midiIn)
+      .openMidiOut(midiOut)
       .or(() => this.midiError());
   }
 
   private midiError() {
-    if (this._onDisconnect) this._onDisconnect();
-    throw new midiError('Device not connected.');
+    if (this._onDisconnect) {
+      this._onDisconnect();
+    }
+    this.closeAll();
+    console.error(new midiError('Device not connected.'));
   }
 
   private openOutput() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ class LaunchpadCore<T extends StringDrivers> {
     onMidiIn: [],
     onConnected: [],
     onDisabled: [],
+    onDisconnected: [],
   };
 
   constructor(driverName: T) {
@@ -23,7 +24,11 @@ class LaunchpadCore<T extends StringDrivers> {
       MidiService.requestWebAccess().catch(() => {});
     }
 
-    this._instance = new MidiService(this._driver.MidiIn, this._driver.MidiOut);
+    this._instance = new MidiService(
+      this._driver.MidiIn,
+      this._driver.MidiOut,
+      () => this.onDisconnected(),
+    );
 
     this.onEnabled();
 
@@ -45,6 +50,10 @@ class LaunchpadCore<T extends StringDrivers> {
     this._instance.closeAll();
   }
 
+  private async onDisconnected() {
+    await this.handleEvent('onDisconnected', this._instance, this._driver);
+  }
+
   /**
    * Events
    */
@@ -55,6 +64,7 @@ class LaunchpadCore<T extends StringDrivers> {
   public on(event: 'onMidiIn', callback: (data: any) => void): void;
   public on(event: 'onConnected', callback: (instance: MidiService, driver: DriverMap[T]) => void): void;
   public on(event: 'onDisabled', callback: (instance: MidiService, driver: DriverMap[T]) => void): void;
+  public on(event: 'onDisconnected', callback: (instance: MidiService, driver: DriverMap[T]) => void): void;
 
   public on(event: string, callback: any) {
     if (!this.callbacks[event]) throw new Error(`Unknown event name: '${event}'`);


### PR DESCRIPTION
## Summary
- emit `onDisconnected` when the launchpad disconnects
- expose new event in LaunchpadCore and MidiService
- document the event and show usage example

## Testing
- `npm run build` *(fails: rollup not found before installing)*
- `npm install --ignore-scripts`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684321b028dc8329990bcf31834a3a41